### PR TITLE
Add CLI, README updates and run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,41 +19,59 @@ recognition and sight-reading skills.
 
 ## Usage
 
-1. **Modify the Script:**
-   - Open `sight_reading.py` in a text editor.
-   - Locate the line `key = key_c` and change it to the key you want to
-     practice.
-     - For example, `key = key_a` for the key of A.
-     - Sharp keys are named with an `is` suffix (e.g., key F sharp is
-       `key_fis`).
-     - Flat keys are named with an `es` suffix (e.g., key B flat is `key_bes`).
+1. Command-line usage
 
-2. **Generate the LilyPond File:**
-   - Run the script and redirect the output to a `.ly` file:
-     ```bash
-     python3 sight_reading.py > key_c.ly
-     ```
-   - Replace `key_c.ly` with the desired key name.
+   The script accepts command-line options to select the key and to
+   enable/disable shuffling of the generated notes. Use the `--key` option
+   to choose which `key_` definition from `keys.py` will be used.
 
-3. **Create the Music Score and MIDI File:**
+   - `--key=<name>`: Choose the key to generate. For example `--key=c` will use
+     `key_c` as defined in `keys.py`. Valid values correspond to the
+     `key_` variables (for example: `c`, `g`, `f`, `d`, `bes`, `a`, `ees`,
+     `e`, `aes`, `b`, etc.).
+   - `--shuffle` / `--no-shuffle`: Control whether notes are shuffled. Use
+     `--no-shuffle` to produce a deterministic, unshuffled sequence.
+
+   Example: generate LilyPond for C major (shuffled):
+
+   ```bash
+   python3 sight_reading.py --key=c > key_c.ly
+   ```
+
+   Example: generate LilyPond for A major without shuffling:
+
+   ```bash
+   python3 sight_reading.py --key=a --no-shuffle > key_a.ly
+   ```
+
+2. Create the Music Score and MIDI File
+
    - Use LilyPond to generate the PDF and MIDI files:
+
      ```bash
      lilypond key_c.ly
      ```
+
    - This command will generate `key_c.pdf` and `key_c.midi` files.
 
-4. **Convert MIDI to Audio:**
+3. Convert MIDI to Audio
+
    - Use TiMidity++ to convert the MIDI file to a WAV audio file:
+
      ```bash
      timidity -Ow key_c.midi
      ```
+
    - This command will generate a `key_c.wav` file.
 
-5. **Compress the Audio File:**
+4. Compress the Audio File
+
    - Use LAME to compress the WAV file to MP3 format:
+
      ```bash
      lame key_c.wav
      ```
+
    - This command will generate a `key_c.mp3` file.
 
 After completing these steps, you will have a PDF music score and an MP3 audio

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# run.sh
+# Iterate through keys defined in key_generator.py, generate LilyPond (.ly),
+# then produce PDF/MIDI (via lilypond) and WAV/MP3 (via timidity + lame).
+
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT_DIR"
+
+# Determine keys list by parsing `key_generator.py` only.
+if [ ! -f key_generator.py ]; then
+  echo "Error: key_generator.py not found in repository root; cannot discover keys."
+  exit 1
+fi
+
+KEYS=$(grep -oE 'key_[A-Za-z]+' key_generator.py 2>/dev/null | sort -u | sed 's/^key_//') || true
+KEYS=$(echo "$KEYS" | xargs) || true
+if [ -z "$KEYS" ]; then
+  echo "No keys found in key_generator.py (looking for variables named key_*)"
+  exit 1
+fi
+
+echo "Found keys: $KEYS"
+
+for cmd in python3 lilypond timidity lame; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Warning: $cmd not found in PATH; some steps may be skipped."
+  fi
+done
+
+for k in $KEYS; do
+  echo
+  echo "=== Processing key: $k ==="
+  ly="key_${k}.ly"
+  midi="key_${k}.midi"
+  wav="key_${k}.wav"
+  mp3="key_${k}.mp3"
+
+  echo "Generating LilyPond source: $ly"
+  if ! python3 sight_reading.py --key="$k" > "$ly"; then
+    echo "ERROR: sight_reading.py failed for key $k"
+    continue
+  fi
+
+  echo "Running lilypond to create PDF & MIDI"
+  if ! lilypond --version >/dev/null 2>&1; then
+    echo "lilypond not available; skipping lilypond step for $k"
+    continue
+  fi
+
+  if ! lilypond "$ly"; then
+    echo "lilypond failed for $ly"
+    continue
+  fi
+
+  if [ ! -f "$midi" ]; then
+    echo "No MIDI produced for $k (expected $midi); skipping audio conversion"
+    continue
+  fi
+
+  if command -v timidity >/dev/null 2>&1; then
+    echo "Converting MIDI -> WAV: $midi -> $wav"
+    if ! timidity -Ow -o "$wav" "$midi"; then
+      echo "timidity failed for $midi"
+      continue
+    fi
+  else
+    echo "timidity not found; skipping WAV/MP3 generation for $k"
+    continue
+  fi
+
+  if command -v lame >/dev/null 2>&1; then
+    echo "Encoding WAV -> MP3: $wav -> $mp3"
+    if ! lame -V2 "$wav" "$mp3"; then
+      echo "lame failed for $wav"
+      continue
+    fi
+    rm -f "$wav"
+  else
+    echo "lame not found; keeping WAV file: $wav"
+  fi
+
+  echo "Finished $k: PDF and audio (if tools available)"
+done
+
+echo
+echo "All done."

--- a/sight_reading.py
+++ b/sight_reading.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
-from key_generator import key_c, key_g, key_f, key_d, key_bes, key_a, key_ees, key_e, key_aes, key_b
 import random
+import argparse
+import sys
+
+from key_generator import key_c, key_g, key_f, key_d, key_bes, key_a, key_ees, key_e, key_aes, key_b
 
 def generate_sight_reading_exercise(key, shuffle):
     """
@@ -97,7 +100,41 @@ def main():
     """
     Main function to generate the sight-reading exercise.
     """
-    generate_sight_reading_exercise(key_c, True)
+    parser = argparse.ArgumentParser(description="Generate a sight-reading exercise.")
+    parser.add_argument("--key", dest="key", default="c",
+                        help="Key to generate: c, g, f, d, bes, a, ees, e, aes, b (defaults to c)")
+    # allow explicit enable/disable of shuffle
+    parser.add_argument("--shuffle", dest="shuffle", action=argparse.BooleanOptionalAction,
+                        default=True,
+                        help="Enable or disable shuffling of notes (default: enabled)")
+
+    args = parser.parse_args()
+
+    # Map common names to the imported key objects
+    key_map = {
+        "c": key_c,
+        "g": key_g,
+        "f": key_f,
+        "d": key_d,
+        "bes": key_bes,
+        "bb": key_bes,
+        "a": key_a,
+        "ees": key_ees,
+        "eb": key_ees,
+        "e": key_e,
+        "aes": key_aes,
+        "ab": key_aes,
+        "b": key_b,
+    }
+
+    key_name = args.key.lower()
+    if key_name not in key_map:
+        print(f"Unknown key '{args.key}'. Valid keys: {', '.join(sorted(key_map.keys()))}")
+        sys.exit(2)
+
+    selected_key = key_map[key_name]
+
+    generate_sight_reading_exercise(selected_key, args.shuffle)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Implement command-line options for `sight_reading.py`:
  - `--key` to select which `key_` to use
  - `--shuffle`/`--no-shuffle` to control shuffling.
- Update `README.md` to document the CLI usage and examples.
- Add `run.sh` that iterates keys (discovered from `key_generator.py`) to produce LilyPond PDF/MIDI and convert MIDI->MP3 (when external tools are available).